### PR TITLE
Fix local network access prompts in multi-site analysis

### DIFF
--- a/src/store/useSimulationStore.js
+++ b/src/store/useSimulationStore.js
@@ -50,10 +50,8 @@ const useSimulationStore = create((set, get) => ({
     set({ isScanning: true, scanProgress: 0, results: null, compositeOverlay: null, interNodeLinks: null, totalUniqueCoverageKm2: null });
     
     try {
-      const API_TARGET = import.meta.env.VITE_API_URL || 'http://localhost:5001';
-      
       // 1. Trigger Scan
-      const response = await fetch(`${API_TARGET}/scan/start`, {
+      const response = await fetch('/api/scan/start', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ nodes, optimize_n: optimizeN }),
@@ -74,8 +72,7 @@ const useSimulationStore = create((set, get) => ({
   },
   
   listenToProgress: (taskId) => {
-    const API_TARGET = import.meta.env.VITE_API_URL || 'http://localhost:5001';
-    const eventSource = new EventSource(`${API_TARGET}/task_status/${taskId}`);
+    const eventSource = new EventSource(`/api/task_status/${taskId}`);
     
     eventSource.onmessage = (event) => {
       let payload;


### PR DESCRIPTION
Replace hardcoded http://localhost:5001 fallback with relative /api paths
in useSimulationStore.js. The scan/start fetch and task_status SSE
connection were bypassing the Nginx/Vite proxy, causing browsers to
trigger Private Network Access prompts.

https://claude.ai/code/session_01PkyUMCPmh7jUm4BYjeV5dd